### PR TITLE
Update README.md consume command

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ framework:
 5. Consume!
 
 ```bash
-bin/console messenger:consume-messages amqp
+bin/console messenger:consume amqp
 ```
 
 ## Advanced usage


### PR DESCRIPTION
This solving deprecation note for Messenger 4.3:
> [php] User Deprecated: The use of the "messenger:consume-messages" command is deprecated since version 4.3 and will be removed in 5.0. Use "messenger:consume" instead.