### PR TITLE
Fix snsqs redelivery

### DIFF
--- a/QueueInteropTransport.php
+++ b/QueueInteropTransport.php
@@ -139,7 +139,11 @@ class QueueInteropTransport implements TransportInterface
 
         $producer = $context->createProducer();
 
-        if (null !== $envelope->last(RedeliveryStamp::class) && $producer instanceof SnsQsProducer) {
+        if (
+            isset($destination['queue'])
+            && null !== $envelope->last(RedeliveryStamp::class)
+            && $producer instanceof SnsQsProducer
+        ) {
             $topic = $context->createQueue($destination['queue']);
         }
 

--- a/composer.json
+++ b/composer.json
@@ -39,6 +39,7 @@
     "require-dev": {
         "phpspec/prophecy": "^1.8.0",
         "phpunit/phpunit": "^7.1",
-        "symfony/yaml": "^3.4|^4.1|^5"
+        "symfony/yaml": "^3.4|^4.1|^5",
+        "enqueue/snsqs": "^0.10.11"
     }
 }


### PR DESCRIPTION
When resending a message for retry on enqueue/snsqs transport, we need to send the message to the queue rather than the topic.﻿
