### PR TITLE
Add PHP 8.1 support

### DIFF
--- a/EnvelopeItem/TransportConfiguration.php
+++ b/EnvelopeItem/TransportConfiguration.php
@@ -107,6 +107,11 @@ final class TransportConfiguration implements StampInterface, \Serializable
         ));
     }
 
+    public function __serialize(): ?string
+    {
+        return $this->serialize();
+    }
+
     public function unserialize($serialized)
     {
         list(
@@ -118,5 +123,10 @@ final class TransportConfiguration implements StampInterface, \Serializable
             'topic' => $topic,
             'metadata' => $metadata,
         ));
+    }
+
+    public function __unserialize(string $data): void
+    {
+        $this->unserialize($data);
     }
 }


### PR DESCRIPTION
Solves the deprecation:
```
Deprecated: Enqueue\MessengerAdapter\EnvelopeItem\TransportConfiguration implements the Serializable interface, which is deprecated. Implement __serialize() and __unserialize() instead (or in addition, if support for old PHP versions is necessary) in /var/www/html/sw6/vendor/sroze/messenger-enqueue-transport/EnvelopeItem/TransportConfiguration.php on line 24
```