### PR TITLE
added ability to send message attributes for amazon (snsqs, sqs) transports

### DIFF
--- a/EnvelopeItem/MessageAttributesStamp.php
+++ b/EnvelopeItem/MessageAttributesStamp.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Enqueue\MessengerAdapter\EnvelopeItem;
+
+use Enqueue\MessengerAdapter\Model\MessageAttributes;
+use Interop\Queue\Message;
+use Symfony\Component\Messenger\Stamp\NonSendableStampInterface;
+
+final class MessageAttributesStamp implements NonSendableStampInterface
+{
+    /** @var MessageAttributes */
+    private $attributes;
+
+    public function __construct(MessageAttributes $attributes)
+    {
+        $this->attributes = $attributes;
+    }
+
+    public function getAttributes(): MessageAttributes
+    {
+        return $this->attributes;
+    }
+}

--- a/Model/MessageAttributes.php
+++ b/Model/MessageAttributes.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Enqueue\MessengerAdapter\Model;
+
+final class MessageAttributes
+{
+    /** @var array<string, string> */
+    private $attributes;
+
+    /** @param array<string, string> $attributes */
+    public function __construct(array $attributes)
+    {
+        if (empty($attributes)) {
+            throw new \InvalidArgumentException('MessageAttributes should have at least one attribute');
+        }
+        \array_walk($attributes, function (string $value, string $name) {
+            return $this->add($name, $value);
+        });
+    }
+
+    /** @return array<string, array<string, string>> */
+    public function toArray(): array
+    {
+        $result = array();
+        foreach ($this->attributes as $name => $value) {
+            $result[$name] = array(
+                'DataType' => 'String',
+                'StringValue' => $value,
+            );
+        }
+
+        return $result;
+    }
+
+    public static function merge(self ...$messageAttributes): self
+    {
+        return new self(
+            \array_merge(
+                ...\array_map(static function (MessageAttributes $attributes) {
+                    return $attributes->attributes;
+                }, $messageAttributes)
+            )
+        );
+    }
+
+    private function add(string $name, string $value): void
+    {
+        if (0 === \preg_match('/^[A-Za-z0-9-_.]{1,256}$/', $name)) {
+            throw new \InvalidArgumentException(
+                \sprintf(
+                    '"%s" is invalid massage attribute name. See details here: %s',
+                    $name,
+                    'https://docs.aws.amazon.com/sns/latest/dg/sns-message-attributes.html'
+                )
+            );
+        }
+
+        $this->attributes[$name] = $value;
+    }
+}

--- a/Tests/Model/MessageAttributesTest.php
+++ b/Tests/Model/MessageAttributesTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Enqueue\MessengerAdapter\Tests\Model;
+
+use Enqueue\MessengerAdapter\Model\MessageAttributes;
+use PHPUnit\Framework\TestCase;
+
+class MessageAttributesTest extends TestCase
+{
+    public function testToArray()
+    {
+        $messageAttributes = new MessageAttributes(array('attr1' => 'value1'));
+        $this->assertSame(
+            array(
+                'attr1' => array(
+                    'DataType' => 'String',
+                    'StringValue' => 'value1',
+                ),
+            ),
+            $messageAttributes->toArray()
+        );
+    }
+
+    public function testMerge()
+    {
+        $this->assertEquals(
+            new MessageAttributes(array('attr1' => 'value1', 'attr2' => 'value2')),
+            MessageAttributes::merge(
+                new MessageAttributes(array('attr1' => 'value1')),
+                new MessageAttributes(array('attr2' => 'value2'))
+            )
+        );
+    }
+
+    public function testThrowExceptionForInvalidAttribute()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        new MessageAttributes(array('invalidKey****' => 'value1'));
+    }
+}


### PR DESCRIPTION
Some time ago to enqueue was added possibility to send message attributes using snsqs transport (https://github.com/php-enqueue/enqueue-dev/pull/1195/files)
This PR allows sending these message attributes using stamp