### PR TITLE
Add partition selector feature

### DIFF
--- a/EnvelopeItem/PartitionStamp.php
+++ b/EnvelopeItem/PartitionStamp.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Enqueue\MessengerAdapter\EnvelopeItem;
+
+use Interop\Queue\Message;
+use Symfony\Component\Messenger\Stamp\NonSendableStampInterface;
+use Symfony\Component\Messenger\Stamp\StampInterface;
+
+class PartitionStamp implements StampInterface
+{
+    private int $partition;
+
+    public function getPartition(): int
+    {
+        return $this->partition;
+    }
+
+    public function setPartition(int $partition): self
+    {
+        $this->partition = $partition;
+        
+        return $this;
+    }
+}

--- a/QueueInteropTransport.php
+++ b/QueueInteropTransport.php
@@ -15,6 +15,7 @@ use Enqueue\AmqpTools\DelayStrategyAware;
 use Enqueue\AmqpTools\RabbitMqDelayPluginDelayStrategy;
 use Enqueue\AmqpTools\RabbitMqDlxDelayStrategy;
 use Enqueue\MessengerAdapter\EnvelopeItem\InteropMessageStamp;
+use Enqueue\MessengerAdapter\EnvelopeItem\PartitionStamp;
 use Enqueue\MessengerAdapter\EnvelopeItem\TransportConfiguration;
 use Enqueue\MessengerAdapter\Exception\MissingMessageMetadataSetterException;
 use Enqueue\MessengerAdapter\Exception\SendingMessageFailedException;
@@ -166,6 +167,11 @@ class QueueInteropTransport implements TransportInterface
         }
         if (isset($this->options['timeToLive'])) {
             $producer->setTimeToLive($this->options['timeToLive']);
+        }
+
+        $partitionStamp = $envelope->last(PartitionStamp::class);
+        if (method_exists($interopMessage, 'setPartition') && !is_null($partitionStamp)) {
+            $interopMessage->setPartition($partitionStamp->getPartition());
         }
 
         try {

--- a/Tests/EnvelopeItem/PartitionStampTest.php
+++ b/Tests/EnvelopeItem/PartitionStampTest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Enqueue\MessengerAdapter\Tests\EnvelopeItem;
+
+use Enqueue\MessengerAdapter\EnvelopeItem\PartitionStamp;
+use PHPUnit\Framework\TestCase;
+
+class PartitionStampTest extends TestCase
+{
+    public function testPartitionSetter()
+    {
+        $partitionStamp = (new PartitionStamp())->setPartition(1);
+        $this->assertInstanceOf(PartitionStamp::class, $partitionStamp);
+    }
+
+    public function testPartitionGetter()
+    {
+        $partitionStamp = (new PartitionStamp())->setPartition(1);
+        $this->assertEquals(1, $partitionStamp->getPartition());
+    }
+}


### PR DESCRIPTION
Add partition stamp for selecting the destination partition in Kafka.

This stamp can be added in a Messenger Middleware to choose the partition.

I didn't know the dependency versions to run the tests and i found that with this docker composer image the tests didn't throw any warning and are all ok

`docker run --rm --interactive --tty --volume $PWD:/app composer:1.10.13 /bin/bash -c "composer install && vendor/bin/phpunit"`

[https://github.com/sroze/messenger-enqueue-transport/pull/53#issuecomment-1677054289](https://github.com/sroze/messenger-enqueue-transport/pull/53#issuecomment-1677054289)

