### PR TITLE
Key and partition selector

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+/Tests export-ignore

--- a/EnvelopeItem/KeyStamp.php
+++ b/EnvelopeItem/KeyStamp.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Enqueue\MessengerAdapter\EnvelopeItem;
+
+use Interop\Queue\Message;
+use Symfony\Component\Messenger\Stamp\NonSendableStampInterface;
+use Symfony\Component\Messenger\Stamp\StampInterface;
+
+class KeyStamp implements StampInterface
+{
+    private string $key;
+
+    public function getKey(): ?string
+    {
+        return $this->key;
+    }
+
+    public function setKey(string $key = null): self
+    {
+        $this->key = $key;
+
+        return $this;
+    }
+}

--- a/EnvelopeItem/PartitionStamp.php
+++ b/EnvelopeItem/PartitionStamp.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Enqueue\MessengerAdapter\EnvelopeItem;
+
+use Interop\Queue\Message;
+use Symfony\Component\Messenger\Stamp\NonSendableStampInterface;
+use Symfony\Component\Messenger\Stamp\StampInterface;
+
+class PartitionStamp implements StampInterface
+{
+    private int $partition;
+
+    public function getPartition(): int
+    {
+        return $this->partition;
+    }
+
+    public function setPartition(int $partition): self
+    {
+        $this->partition = $partition;
+        
+        return $this;
+    }
+}

--- a/QueueInteropTransport.php
+++ b/QueueInteropTransport.php
@@ -15,6 +15,7 @@ use Enqueue\AmqpTools\DelayStrategyAware;
 use Enqueue\AmqpTools\RabbitMqDelayPluginDelayStrategy;
 use Enqueue\AmqpTools\RabbitMqDlxDelayStrategy;
 use Enqueue\MessengerAdapter\EnvelopeItem\InteropMessageStamp;
+use Enqueue\MessengerAdapter\EnvelopeItem\PartitionStamp;
 use Enqueue\MessengerAdapter\EnvelopeItem\TransportConfiguration;
 use Enqueue\MessengerAdapter\Exception\MissingMessageMetadataSetterException;
 use Enqueue\MessengerAdapter\Exception\SendingMessageFailedException;
@@ -166,6 +167,11 @@ class QueueInteropTransport implements TransportInterface
         }
         if (isset($this->options['timeToLive'])) {
             $producer->setTimeToLive($this->options['timeToLive']);
+        }
+
+        $partitionStamp = $envelope->last(PartitionStamp::class);
+        if (method_exists($interopMessage, 'setPartition') && !is_null($partitionStamp)) {
+            $interopMessage->setPartition($partitionStamp->getPartition());
         }
 
         try {

--- a/QueueInteropTransport.php
+++ b/QueueInteropTransport.php
@@ -15,6 +15,7 @@ use Enqueue\AmqpTools\DelayStrategyAware;
 use Enqueue\AmqpTools\RabbitMqDelayPluginDelayStrategy;
 use Enqueue\AmqpTools\RabbitMqDlxDelayStrategy;
 use Enqueue\MessengerAdapter\EnvelopeItem\InteropMessageStamp;
+use Enqueue\MessengerAdapter\EnvelopeItem\KeyStamp;
 use Enqueue\MessengerAdapter\EnvelopeItem\PartitionStamp;
 use Enqueue\MessengerAdapter\EnvelopeItem\TransportConfiguration;
 use Enqueue\MessengerAdapter\Exception\MissingMessageMetadataSetterException;
@@ -172,6 +173,16 @@ class QueueInteropTransport implements TransportInterface
         $partitionStamp = $envelope->last(PartitionStamp::class);
         if (method_exists($interopMessage, 'setPartition') && !is_null($partitionStamp)) {
             $interopMessage->setPartition($partitionStamp->getPartition());
+        }
+
+        $partitionStamp = $envelope->last(PartitionStamp::class);
+        if (method_exists($interopMessage, 'setPartition') && !is_null($partitionStamp)) {
+            $interopMessage->setPartition($partitionStamp->getPartition());
+        }
+
+        $keyStamp = $envelope->last(KeyStamp::class);
+        if (method_exists($interopMessage, 'setKey') && !is_null($keyStamp)) {
+            $interopMessage->setKey($keyStamp->getKey());
         }
 
         try {

--- a/QueueInteropTransport.php
+++ b/QueueInteropTransport.php
@@ -175,11 +175,6 @@ class QueueInteropTransport implements TransportInterface
             $interopMessage->setPartition($partitionStamp->getPartition());
         }
 
-        $partitionStamp = $envelope->last(PartitionStamp::class);
-        if (method_exists($interopMessage, 'setPartition') && !is_null($partitionStamp)) {
-            $interopMessage->setPartition($partitionStamp->getPartition());
-        }
-
         $keyStamp = $envelope->last(KeyStamp::class);
         if (method_exists($interopMessage, 'setKey') && !is_null($keyStamp)) {
             $interopMessage->setKey($keyStamp->getKey());

--- a/Tests/EnvelopeItem/KeyStampTest.php
+++ b/Tests/EnvelopeItem/KeyStampTest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Enqueue\MessengerAdapter\Tests\EnvelopeItem;
+
+use Enqueue\MessengerAdapter\EnvelopeItem\KeyStamp;
+use PHPUnit\Framework\TestCase;
+
+class KeyStampTest extends TestCase
+{
+    public function testPartitionSetter()
+    {
+        $keyStamp = (new KeyStamp())->setKey('key');
+        $this->assertInstanceOf(KeyStamp::class, $keyStamp);
+    }
+
+    public function testPartitionGetter()
+    {
+        $keyStamp = (new KeyStamp())->setKey('key');
+        $this->assertEquals('key', $keyStamp->getKey());
+    }
+}

--- a/Tests/EnvelopeItem/PartitionStampTest.php
+++ b/Tests/EnvelopeItem/PartitionStampTest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Enqueue\MessengerAdapter\Tests\EnvelopeItem;
+
+use Enqueue\MessengerAdapter\EnvelopeItem\PartitionStamp;
+use PHPUnit\Framework\TestCase;
+
+class PartitionStampTest extends TestCase
+{
+    public function testPartitionSetter()
+    {
+        $partitionStamp = (new PartitionStamp())->setPartition(1);
+        $this->assertInstanceOf(PartitionStamp::class, $partitionStamp);
+    }
+
+    public function testPartitionGetter()
+    {
+        $partitionStamp = (new PartitionStamp())->setPartition(1);
+        $this->assertEquals(1, $partitionStamp->getPartition());
+    }
+}


### PR DESCRIPTION
Add [partition](https://github.com/php-enqueue/rdkafka/blob/master/RdKafkaMessage.php#L162) stamp for selecting the destination partition in Kafka.
Add [key](https://github.com/php-enqueue/rdkafka/blob/master/RdKafkaMessage.php#L172) stamp for adding a key to kafka message

Those stamps can be added in a Messenger Middleware to choose the partition or add a key.

I didn't know the dependency versions to run the tests and i found that with this docker composer image the tests didn't throw any warning and are all ok

docker run --rm --interactive --tty --volume $PWD:/app composer:1.10.13 /bin/bash -c "composer install && vendor/bin/phpunit"

https://github.com/sroze/messenger-enqueue-transport/pull/53#issuecomment-1677054289