### PR TITLE
Add CI; drop EOL PHP and Symfony versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,45 @@
+name: CI
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        php: ['8.1', '8.2', '8.3']
+        symfony_version: ['5.4.*', '6.3.*', '6.4.*', '7.0.*']
+        dependencies: ['--prefer-lowest', '--prefer-dist']
+
+    name: PHP ${{ matrix.php }} tests on Sf ${{ matrix.symfony_version }}, deps=${{ matrix.dependencies }}
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Get Composer Cache Directory
+        id: composer-cache
+        run: |
+          echo "::set-output name=dir::$(composer config cache-files-dir)"
+
+      - uses: actions/cache@v2
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: composer-${{ matrix.php }}-${{ matrix.symfony_version }}-${{ matrix.dependencies }}-${{ hashFiles('**/composer.json') }}
+          restore-keys: |
+            composer-${{ matrix.php }}-${{ matrix.symfony_version }}-${{ matrix.dependencies }}-
+
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          coverage: none
+          extensions: :xdebug
+
+      - run: php ./Tests/bin/pin-symfony-version.php "${{ matrix.symfony_version }}"
+
+      - run: composer update --no-progress ${{ matrix.dependencies }}
+
+      - run: ./vendor/bin/phpunit

--- a/Tests/bin/pin-symfony-version.php
+++ b/Tests/bin/pin-symfony-version.php
@@ -1,0 +1,15 @@
+#!/usr/bin/env php
+<?php
+
+if (empty($argv[1])) {
+    throw new \LogicException('Provide a Symfony version in Composer requirement format (e.g. "^7.0")');
+}
+
+$newVersion = $argv[1];
+
+$composer = file_get_contents(__DIR__.'/../composer.json');
+
+$updatedComposer = preg_replace('/"symfony\/(.*)": ".*"/', '"symfony/$1": "'.$newVersion.'"', $composer).PHP_EOL;
+echo $updatedComposer.PHP_EOL;
+
+file_put_contents(__DIR__.'/../composer.json', $updatedComposer);

--- a/composer.json
+++ b/composer.json
@@ -17,8 +17,8 @@
     ],
     "require": {
         "enqueue/enqueue-bundle": "^0.10",
-        "symfony/messenger": "^4.3 || ^5.0 || ^6.0 || ^7.0",
-        "symfony/options-resolver": "^3.4 || ^4.2 || ^5.0 || ^6.0 || ^7.0",
+        "symfony/messenger": "^5.4 || ^6.3 || ^7.0",
+        "symfony/options-resolver": "^5.4 || ^6.3 || ^7.0",
         "enqueue/amqp-tools": "^0.10"
     },
     "replace": {
@@ -38,7 +38,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5",
-        "symfony/yaml": "^3.4|^4.1|^5|^6",
+        "symfony/yaml": "^5.4 || ^6.3 || ^7.0",
         "enqueue/snsqs": "^0.10.11",
         "phpspec/prophecy-phpunit": "^2.0",
         "phpspec/prophecy": "^1.15"


### PR DESCRIPTION
- Add CI which runs existing tests;
- Do not add EOL PHP and Symfony versions to the build matrix;
- Drop the EOL versions from composer.json.
