### PR TITLE
Fix build

### DIFF
--- a/QueueInteropTransport.php
+++ b/QueueInteropTransport.php
@@ -172,7 +172,7 @@ class QueueInteropTransport implements TransportInterface
             $producer->send($topic, $interopMessage);
         } catch (InteropQueueException $e) {
             if (!$this->contextManager->recoverException($e, $destination)) {
-                throw new SendingMessageFailedException($e->getMessage(), null, $e);
+                throw new SendingMessageFailedException(message: $e->getMessage(), previous: $e);
             }
 
             // The context manager recovered the exception, we re-try.

--- a/Tests/QueueInteropTransportFactoryTest.php
+++ b/Tests/QueueInteropTransportFactoryTest.php
@@ -94,7 +94,7 @@ class QueueInteropTransportFactoryTest extends TestCase
         $container = $this->prophesize(ContainerInterface::class);
         $container->has('enqueue.transport.foo.context')->willReturn(false);
 
-        $factory = $this->getFactory();
+        $factory = $this->getFactory(container: $container->reveal());
         $factory->createTransport('enqueue://foo', array());
     }
 

--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
         }
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.5",
+        "phpunit/phpunit": "^10.0",
         "symfony/yaml": "^5.4 || ^6.3 || ^7.0",
         "enqueue/snsqs": "^0.10.11",
         "phpspec/prophecy-phpunit": "^2.0",

--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
         }
     ],
     "require": {
+        "php": "^8.1",
         "enqueue/enqueue-bundle": "^0.10",
         "symfony/messenger": "^5.4 || ^6.3 || ^7.0",
         "symfony/options-resolver": "^5.4 || ^6.3 || ^7.0",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/9.5/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
          backupGlobals="false"
          colors="true"
          bootstrap="vendor/autoload.php"
@@ -18,7 +18,7 @@
         </testsuite>
     </testsuites>
 
-    <coverage>
+    <source>
         <include>
             <directory suffix=".php">./</directory>
         </include>
@@ -26,5 +26,5 @@
             <directory>./Tests</directory>
             <directory>./vendor</directory>
         </exclude>
-    </coverage>
+    </source>
 </phpunit>


### PR DESCRIPTION
- Fix a deprecation which made _all_ the builds red;
- Add the PHP requirement to composer.json to prevent misunderstandings about the new syntax;
- Fix using a prophecy in a particular test;
- Update PHPUnit to v10 to avoid deprecations on PHP 8.2+
