### PR TITLE
Bump PHP version to 8.2 since it's newest stable version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^8.1",
+        "php": "^8.2",
         "enqueue/enqueue-bundle": "^0.10",
         "symfony/messenger": "^5.4 || ^6.3 || ^7.0",
         "symfony/options-resolver": "^5.4 || ^6.3 || ^7.0",


### PR DESCRIPTION
This merge request proposes upgrading the PHP version to 8.2, the latest stable release. 