### PR TITLE
Add Symfony 8; drop EOL versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         php: ['8.2', '8.3', '8.4']
-        symfony_version: ['6.4.*', '7.0.*', '8.0.*']
+        symfony_version: ['6.4.*', '7.3.*', '7.4.*', '8.0.*']
         dependencies: ['lowest', 'highest']
         exclude:
           - php: '8.2'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,26 +11,19 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['8.1', '8.2', '8.3']
-        symfony_version: ['5.4.*', '6.3.*', '6.4.*', '7.0.*']
-        dependencies: ['--prefer-lowest', '--prefer-dist']
+        php: ['8.2', '8.3', '8.4']
+        symfony_version: ['6.4.*', '7.0.*', '8.0.*']
+        dependencies: ['lowest', 'highest']
+        exclude:
+          - php: '8.2'
+            symfony_version: '8.0.*'
+          - php: '8.3'
+            symfony_version: '8.0.*'
 
     name: PHP ${{ matrix.php }} tests on Sf ${{ matrix.symfony_version }}, deps=${{ matrix.dependencies }}
 
     steps:
       - uses: actions/checkout@v2
-
-      - name: Get Composer Cache Directory
-        id: composer-cache
-        run: |
-          echo "::set-output name=dir::$(composer config cache-files-dir)"
-
-      - uses: actions/cache@v2
-        with:
-          path: ${{ steps.composer-cache.outputs.dir }}
-          key: composer-${{ matrix.php }}-${{ matrix.symfony_version }}-${{ matrix.dependencies }}-${{ hashFiles('**/composer.json') }}
-          restore-keys: |
-            composer-${{ matrix.php }}-${{ matrix.symfony_version }}-${{ matrix.dependencies }}-
 
       - uses: shivammathur/setup-php@v2
         with:
@@ -40,6 +33,8 @@ jobs:
 
       - run: php ./Tests/bin/pin-symfony-version.php "${{ matrix.symfony_version }}"
 
-      - run: composer update --no-progress ${{ matrix.dependencies }}
+      - uses: "ramsey/composer-install@v3"
+        with:
+          dependency-versions: "${{ matrix.dependencies }}"
 
       - run: ./vendor/bin/phpunit

--- a/Bundle/DependencyInjection/EnqueueAdapterExtension.php
+++ b/Bundle/DependencyInjection/EnqueueAdapterExtension.php
@@ -21,7 +21,7 @@ class EnqueueAdapterExtension extends Extension
     /**
      * {@inheritdoc}
      */
-    public function load(array $configs, ContainerBuilder $container)
+    public function load(array $configs, ContainerBuilder $container): void
     {
         $loader = new YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.yml');

--- a/composer.json
+++ b/composer.json
@@ -18,8 +18,8 @@
     "require": {
         "php": "^8.1",
         "enqueue/enqueue-bundle": "^0.10",
-        "symfony/messenger": "^5.4 || ^6.3 || ^7.0",
-        "symfony/options-resolver": "^5.4 || ^6.3 || ^7.0",
+        "symfony/messenger": "^6.4 || ^7.0 || ^8.0",
+        "symfony/options-resolver": "^6.4 || ^7.0 || ^8.0",
         "enqueue/amqp-tools": "^0.10"
     },
     "replace": {
@@ -39,7 +39,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^10.0",
-        "symfony/yaml": "^5.4 || ^6.3 || ^7.0",
+        "symfony/yaml": "^6.4 || ^7.0 || ^8.0",
         "enqueue/snsqs": "^0.10.11",
         "phpspec/prophecy-phpunit": "^2.0",
         "phpspec/prophecy": "^1.15"


### PR DESCRIPTION
Now that Enqueue has been [updated](https://github.com/php-enqueue/enqueue-dev/commit/2c7f63709dd9f33f99fde106da243cd2eeaf906e), we can do this.

- Add PHP 8.4 to CI
- Add Symfony 7.3, 7.4, 8.0 to CI
- Drop PHP 8.1 from CI, it's EOL on 31.12.2025 — still installable there btw
- Drop EOL Symfony versions — 5.4
- Move composer installing in CI to ramsey/composer-install@v3, we were using caching with set-output, see [github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)
